### PR TITLE
Fix non-default paths

### DIFF
--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -25,7 +25,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
 
         self._address = address
         self._port = port
-        self._path = properties["path"] if "path" in properties else "/"
+        self._path = properties[b'path'].decode("utf-8") if b'path' in properties else "/"
         self._key = key
         self._properties = properties  # Properties dict as provided by zero conf
 
@@ -282,7 +282,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
 
         self.setConnectionState(ConnectionState.connecting)
         self._update()  # Manually trigger the first update, as we don't want to wait a few secs before it starts.
-        Logger.log("d", "Connection with instance %s with ip %s started", self._key, self._address)
+        Logger.log("d", "Connection with instance %s with url %s started", self._key, self._base_url)
         self._update_timer.start()
 
         self._last_response_time = None
@@ -291,7 +291,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
 
     ##  Stop requesting data from the instance
     def disconnect(self):
-        Logger.log("d", "Connection with instance %s with ip %s stopped", self._key, self._address)
+        Logger.log("d", "Connection with instance %s with url %s stopped", self._key, self._base_url)
         self.close()
 
     newImage = pyqtSignal()

--- a/OctoPrintOutputDevicePlugin.py
+++ b/OctoPrintOutputDevicePlugin.py
@@ -60,17 +60,18 @@ class OctoPrintOutputDevicePlugin(OutputDevicePlugin):
 
         # Add manual instances from preference
         for name, properties in self._manual_instances.items():
-            additional_properties = {"path": properties["path"], "manual": True}
+            additional_properties = {b"path": properties["path"].encode("utf-8"), b"manual": b"true"}
             self.addInstance(name, properties["address"], properties["port"], additional_properties)
 
     def addManualInstance(self, name, address, port, path):
         self._manual_instances[name] = {"address": address, "port": port, "path": path}
         self._preferences.setValue("octoprint/manual_instances", json.dumps(self._manual_instances))
 
-        properties = { "path": path, "manual": True }
+        properties = { b"path": path.encode("utf-8"), b"manual": b"true" }
 
         if name in self._instances:
             self.removeInstance(name)
+
         self.addInstance(name, address, port, properties)
         self.instanceListChanged.emit()
 

--- a/OctoPrintOutputDevicePlugin.py
+++ b/OctoPrintOutputDevicePlugin.py
@@ -60,18 +60,17 @@ class OctoPrintOutputDevicePlugin(OutputDevicePlugin):
 
         # Add manual instances from preference
         for name, properties in self._manual_instances.items():
-            additional_properties = {b"path": properties["path"].encode("utf-8"), b"manual": b"true"}
+            additional_properties = {"path": properties["path"], "manual": True}
             self.addInstance(name, properties["address"], properties["port"], additional_properties)
 
     def addManualInstance(self, name, address, port, path):
         self._manual_instances[name] = {"address": address, "port": port, "path": path}
         self._preferences.setValue("octoprint/manual_instances", json.dumps(self._manual_instances))
 
-        properties = { b"path": path.encode("utf-8"), b"manual": b"true" }
+        properties = { "path": path, "manual": True }
 
         if name in self._instances:
             self.removeInstance(name)
-
         self.addInstance(name, address, port, properties)
         self.instanceListChanged.emit()
 


### PR DESCRIPTION
These errant byte arrays caused the system to always use the default path ("/"), occasionally leaving it in an inconsistent state. The GUI would be able to set the path to the correct value, but the correct value would never be reflected in the GUI, even though the preferences file was occasionally correct.  Since the system used the same function to read from a preference file as it did to create the GUI object, the GUI and internal data structures would show the default path.

This occurred because the OctoPrintOutputDevicePlugin.py was passing a dictionary with the keys `b'path'` and `b'manual'` instead of `'path'` and `'manual'`, respectively.  Additionally, their values were also being rendered as byte arrays.  This change naturalizes everything to string and boolean types, which OctoPrintOutputDevice.py expects to receive.

I'm not 100% sure what all happens to the `'manual'` property, but I'm pretty sure this doesn't break anything, especially since `json.loads` and `json.dumps` are dealing with the object when it's supposed to be a byte array. 