### PR TITLE
Add option to use https protocol

### DIFF
--- a/DiscoverOctoPrintAction.py
+++ b/DiscoverOctoPrintAction.py
@@ -54,12 +54,12 @@ class DiscoverOctoPrintAction(MachineAction):
 
         self._network_plugin.removeManualInstance(name)
 
-    @pyqtSlot(str, str, int, str)
-    def setManualInstance(self, name, address, port, path):
+    @pyqtSlot(str, str, int, str, bool)
+    def setManualInstance(self, name, address, port, path, useHttps):
         # This manual printer could replace a current manual printer
         self._network_plugin.removeManualInstance(name)
 
-        self._network_plugin.addManualInstance(name, address, port, path)
+        self._network_plugin.addManualInstance(name, address, port, path, useHttps)
 
     def _onContainerAdded(self, container):
         # Add this action as a supported action to all machine definitions

--- a/DiscoverOctoPrintAction.qml
+++ b/DiscoverOctoPrintAction.qml
@@ -149,10 +149,10 @@ Cura.MachineAction
             Column
             {
                 width: parent.width * 0.5
-                visible: base.selectedInstance != null
                 spacing: UM.Theme.getSize("default_margin").height
                 Label
                 {
+                    visible: base.selectedInstance != null
                     width: parent.width
                     wrapMode: Text.WordWrap
                     text: base.selectedInstance ? base.selectedInstance.name : ""
@@ -161,6 +161,7 @@ Cura.MachineAction
                 }
                 Grid
                 {
+                    visible: base.selectedInstance != null
                     width: parent.width
                     columns: 2
                     rowSpacing: UM.Theme.getSize("default_lining").height
@@ -204,6 +205,7 @@ Cura.MachineAction
 
                 Label
                 {
+                    visible: base.selectedInstance != null
                     text: catalog.i18nc("@label", "Please enter the API key to access OctoPrint above. You can get the OctoPrint API key through the OctoPrint web page.")
                     width: parent.width - UM.Theme.getSize("default_margin").width
                     wrapMode: Text.WordWrap
@@ -211,6 +213,7 @@ Cura.MachineAction
 
                 Column
                 {
+                    visible: base.selectedInstance != null
                     width: parent.width
                     spacing: UM.Theme.getSize("default_lining").height
 
@@ -238,6 +241,7 @@ Cura.MachineAction
 
                 Flow
                 {
+                    visible: base.selectedInstance != null
                     spacing: UM.Theme.getSize("default_margin").width
 
                     Button
@@ -258,8 +262,26 @@ Cura.MachineAction
                         }
                     }
                 }
+
+                Label
+                {
+                    text: catalog.i18nc("@label", "Note: Printing UltiGCode using OctoPrint does not work. Please switch your Gcode flavour to RepRap (Marlin/Sprinter).")
+                    width: parent.width - UM.Theme.getSize("default_margin").width
+                    wrapMode: Text.WordWrap
+                    visible: machineGCodeFlavorProvider.properties.value == "UltiGCode"
+                }
             }
         }
+    }
+
+    UM.SettingPropertyProvider
+    {
+        id: machineGCodeFlavorProvider
+
+        containerStackId: Cura.MachineManager.activeMachineId
+        key: "machine_gcode_flavor"
+        watchedProperties: [ "value" ]
+        storeIndex: 4
     }
 
     UM.Dialog

--- a/DiscoverOctoPrintAction.qml
+++ b/DiscoverOctoPrintAction.qml
@@ -59,7 +59,8 @@ Cura.MachineAction
                 onClicked:
                 {
                     manualPrinterDialog.showDialog(base.selectedInstance.name, base.selectedInstance.ipAddress,
-                                                   base.selectedInstance.port, base.selectedInstance.path, base.selectedInstance.useHttps);
+                                                   base.selectedInstance.port, base.selectedInstance.path,
+                                                   base.selectedInstance.getProperty("useHttps") == "true");
                 }
             }
 

--- a/DiscoverOctoPrintAction.qml
+++ b/DiscoverOctoPrintAction.qml
@@ -47,7 +47,7 @@ Cura.MachineAction
                 text: catalog.i18nc("@action:button", "Add");
                 onClicked:
                 {
-                    manualPrinterDialog.showDialog("", "", "80", "/");
+                    manualPrinterDialog.showDialog("", "", "80", "/", false);
                 }
             }
 
@@ -59,7 +59,7 @@ Cura.MachineAction
                 onClicked:
                 {
                     manualPrinterDialog.showDialog(base.selectedInstance.name, base.selectedInstance.ipAddress,
-                                                   base.selectedInstance.port, base.selectedInstance.path);
+                                                   base.selectedInstance.port, base.selectedInstance.path, base.selectedInstance.useHttps);
                 }
             }
 
@@ -310,7 +310,7 @@ Cura.MachineAction
         width: minimumWidth
         height: minimumHeight
 
-        signal showDialog(string name, string address, string port, string path_)
+        signal showDialog(string name, string address, string port, string path_, bool useHttps)
         onShowDialog:
         {
             oldName = name;
@@ -321,6 +321,7 @@ Cura.MachineAction
             addressText = address;
             portText = port;
             pathText = path_;
+            httpsCheckbox.checked = useHttps;
 
             manualPrinterDialog.show();
         }
@@ -339,7 +340,7 @@ Cura.MachineAction
             {
                 pathText = "/" + pathText // ensure absolute path
             }
-            manager.setManualInstance(nameText, addressText, parseInt(portText), pathText)
+            manager.setManualInstance(nameText, addressText, parseInt(portText), pathText, httpsCheckbox.checked)
         }
 
         Column {
@@ -419,6 +420,17 @@ Cura.MachineAction
                     {
                         regExp: /[a-zA-Z0-9\.\-\_\/]*/
                     }
+                }
+
+                Label
+                {
+                    text: catalog.i18nc("@label","Use HTTPS")
+                    width: parent.width * 0.4
+                }
+
+                CheckBox
+                {
+                    id: httpsCheckbox
                 }
             }
         }

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -267,7 +267,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
 
         self._stopCamera()
 
-    def requestWrite(self, node, file_name = None, filter_by_machine = False):
+    def requestWrite(self, node, file_name = None, filter_by_machine = False, file_handler = None):
         self._gcode = getattr(Application.getInstance().getController().getScene(), "gcode_list")
 
         self.startPrint()

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -25,7 +25,10 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
 
         self._address = address
         self._port = port
-        self._path = properties[b'path'].decode("utf-8") if b'path' in properties else "/"
+        self._path = properties.get(b"path", b"/").decode("utf-8")
+        if self._path[-1:] != "/":
+            self._path += "/"
+        self._useHttps = properties.get(b'useHttps') == b"true"
         self._key = key
         self._properties = properties  # Properties dict as provided by zero conf
 
@@ -41,7 +44,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
         self._api_header = "X-Api-Key"
         self._api_key = None
 
-        self._base_url = "http://%s:%d%s" % (self._address, self._port, self._path)
+        self._base_url = "%s://%s:%d%s" % ("https" if self._useHttps else "http", self._address, self._port, self._path)
         self._api_url = self._base_url + self._api_prefix
         self._camera_url = "http://%s:8080/?action=stream" % self._address
 
@@ -145,6 +148,11 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
     @pyqtProperty(str, constant=True)
     def path(self):
         return self._path
+
+    ## path of this instance
+    @pyqtProperty(bool, constant=True)
+    def useHttps(self):
+        return self._useHttps
 
     ## absolute url of this instance
     @pyqtProperty(str, constant=True)

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -28,7 +28,6 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
         self._path = properties.get(b"path", b"/").decode("utf-8")
         if self._path[-1:] != "/":
             self._path += "/"
-        self._useHttps = properties.get(b'useHttps') == b"true"
         self._key = key
         self._properties = properties  # Properties dict as provided by zero conf
 
@@ -44,9 +43,10 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
         self._api_header = "X-Api-Key"
         self._api_key = None
 
-        self._base_url = "%s://%s:%d%s" % ("https" if self._useHttps else "http", self._address, self._port, self._path)
+        protocol = "https" if properties.get(b'useHttps') == b"true" else "http"
+        self._base_url = "%s://%s:%d%s" % (protocol, self._address, self._port, self._path)
         self._api_url = self._base_url + self._api_prefix
-        self._camera_url = "http://%s:8080/?action=stream" % self._address
+        self._camera_url = "%s://%s:8080/?action=stream" % (protocol, self._address)
 
         self.setPriority(2) # Make sure the output device gets selected above local file output
         self.setName(key)
@@ -148,11 +148,6 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
     @pyqtProperty(str, constant=True)
     def path(self):
         return self._path
-
-    ## path of this instance
-    @pyqtProperty(bool, constant=True)
-    def useHttps(self):
-        return self._useHttps
 
     ## absolute url of this instance
     @pyqtProperty(str, constant=True)

--- a/OctoPrintOutputDevicePlugin.py
+++ b/OctoPrintOutputDevicePlugin.py
@@ -60,14 +60,18 @@ class OctoPrintOutputDevicePlugin(OutputDevicePlugin):
 
         # Add manual instances from preference
         for name, properties in self._manual_instances.items():
-            additional_properties = {b"path": properties["path"].encode("utf-8"), b"manual": b"true"}
+            additional_properties = {
+                b"path": properties["path"].encode("utf-8"),
+                b"useHttps": b"true" if properties.get("useHttps", False) else b"false",
+                b"manual": b"true"
+            } # These additional properties use bytearrays to mimick the output of zeroconf
             self.addInstance(name, properties["address"], properties["port"], additional_properties)
 
-    def addManualInstance(self, name, address, port, path):
-        self._manual_instances[name] = {"address": address, "port": port, "path": path}
+    def addManualInstance(self, name, address, port, path, useHttps = False):
+        self._manual_instances[name] = {"address": address, "port": port, "path": path, "useHttps": useHttps}
         self._preferences.setValue("octoprint/manual_instances", json.dumps(self._manual_instances))
 
-        properties = { b"path": path.encode("utf-8"), b"manual": b"true" }
+        properties = { b"path": path.encode("utf-8"), b"useHttps": b"true" if useHttps else b"false", b"manual": b"true" }
 
         if name in self._instances:
             self.removeInstance(name)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OctoPrintPlugin
-Cura plugin which enables printing directly to OctoPrint and monitoring the process
+Cura plugin which enables printing directly to OctoPrint and monitoring the progress
+
+This plugin started out as a fork of the UM3NetworkPrinting plugin:
+https://github.com/Ultimaker/UM3NetworkPrintingPlugin
 
 Installation
 ----

--- a/README.md
+++ b/README.md
@@ -24,3 +24,26 @@ How to use
   available in the OctoPrint settings.
 - From this point on, the print monitor should be functional and you should be
   able to switch to "Print to Octoprint" on the bottom of the sidebar.
+
+Notes on UltiGCode (Ultimaker 2/Ultimaker 2+)
+----
+The Ultimaker 2(+) family uses a flavor of GCode named UltiGCode. Unfortunately printing
+using UltiGCode flavor does not work when printing over the USB connection. That is why
+using OctoPrint does not work with UltiGCode flavor.
+
+For the Ultimaker 2/Ultimaker 2 Extended, you can use "Machine Settings" on the
+"Printers" pane of the preferences to change your GCode flavor to "RepRap 
+(Marlin/Sprinter)".
+
+The Ultimaker 2+/Ultimaker 2 Extended+ currently don't support "Machine Settings". You
+can use one of these alternative printer definitions instead:
+<dl>
+<dt>Ultimaker2+</dt>
+<dd>https://gist.github.com/fieldOfView/bf536254add126fd4c7b36bc347fce73</dd>
+<dt>Ultimaker2 Extended+</dt>
+<dd>https://gist.github.com/fieldOfView/a52caf946d0a0df522c22298a6c94209</dd>
+</dl>
+Copy these files into the resources/definitions folder of your Cura application.
+Restart Cura and add a new printer. You should see the option to add a Ultimaker
+2+ (RepRap) and/or Ultimaker 2 Extended+ (RepRap) (depending on which file(s)
+you installed.

--- a/__init__.py
+++ b/__init__.py
@@ -11,7 +11,7 @@ def getMetaData():
         "plugin": {
             "name": "OctoPrint connection",
             "author": "fieldOfView",
-            "version": "1.0",
+            "version": "2.4",
             "description": catalog.i18nc("@info:whatsthis", "Allows sending prints to OctoPrint and monitoring the progress"),
             "api": 3
         }


### PR DESCRIPTION
This PR adds an option to use the https protocol instead of http for manual instances. Note that OctoPrint does not natively support https connections, but this may be useful for people that have set up a https-enabled proxy.