### PR TITLE
Add option to use https protocol

### DIFF
--- a/DiscoverOctoPrintAction.py
+++ b/DiscoverOctoPrintAction.py
@@ -54,12 +54,12 @@ class DiscoverOctoPrintAction(MachineAction):
 
         self._network_plugin.removeManualInstance(name)
 
-    @pyqtSlot(str, str, int, str)
-    def setManualInstance(self, name, address, port, path):
+    @pyqtSlot(str, str, int, str, bool)
+    def setManualInstance(self, name, address, port, path, useHttps):
         # This manual printer could replace a current manual printer
         self._network_plugin.removeManualInstance(name)
 
-        self._network_plugin.addManualInstance(name, address, port, path)
+        self._network_plugin.addManualInstance(name, address, port, path, useHttps)
 
     def _onContainerAdded(self, container):
         # Add this action as a supported action to all machine definitions

--- a/DiscoverOctoPrintAction.qml
+++ b/DiscoverOctoPrintAction.qml
@@ -59,7 +59,8 @@ Cura.MachineAction
                 onClicked:
                 {
                     manualPrinterDialog.showDialog(base.selectedInstance.name, base.selectedInstance.ipAddress,
-                                                   base.selectedInstance.port, base.selectedInstance.path, base.selectedInstance.useHttps);
+                                                   base.selectedInstance.port, base.selectedInstance.path,
+                                                   base.selectedInstance.getProperty("useHttps") == "true");
                 }
             }
 

--- a/DiscoverOctoPrintAction.qml
+++ b/DiscoverOctoPrintAction.qml
@@ -47,7 +47,7 @@ Cura.MachineAction
                 text: catalog.i18nc("@action:button", "Add");
                 onClicked:
                 {
-                    manualPrinterDialog.showDialog("", "", "80", "/");
+                    manualPrinterDialog.showDialog("", "", "80", "/", false);
                 }
             }
 
@@ -59,7 +59,7 @@ Cura.MachineAction
                 onClicked:
                 {
                     manualPrinterDialog.showDialog(base.selectedInstance.name, base.selectedInstance.ipAddress,
-                                                   base.selectedInstance.port, base.selectedInstance.path);
+                                                   base.selectedInstance.port, base.selectedInstance.path, base.selectedInstance.useHttps);
                 }
             }
 
@@ -310,7 +310,7 @@ Cura.MachineAction
         width: minimumWidth
         height: minimumHeight
 
-        signal showDialog(string name, string address, string port, string path_)
+        signal showDialog(string name, string address, string port, string path_, bool useHttps)
         onShowDialog:
         {
             oldName = name;
@@ -321,6 +321,7 @@ Cura.MachineAction
             addressText = address;
             portText = port;
             pathText = path_;
+            httpsCheckbox.checked = useHttps;
 
             manualPrinterDialog.show();
         }
@@ -339,7 +340,7 @@ Cura.MachineAction
             {
                 pathText = "/" + pathText // ensure absolute path
             }
-            manager.setManualInstance(nameText, addressText, parseInt(portText), pathText)
+            manager.setManualInstance(nameText, addressText, parseInt(portText), pathText, httpsCheckbox.checked)
         }
 
         Column {
@@ -419,6 +420,17 @@ Cura.MachineAction
                     {
                         regExp: /[a-zA-Z0-9\.\-\_\/]*/
                     }
+                }
+
+                Label
+                {
+                    text: catalog.i18nc("@label","Use HTTPS")
+                    width: parent.width * 0.4
+                }
+
+                CheckBox
+                {
+                    id: httpsCheckbox
                 }
             }
         }

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -25,7 +25,10 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
 
         self._address = address
         self._port = port
-        self._path = properties[b'path'].decode("utf-8") if b'path' in properties else "/"
+        self._path = properties.get(b"path", b"/").decode("utf-8")
+        if self._path[-1:] != "/":
+            self._path += "/"
+        self._useHttps = properties.get(b'useHttps') == b"true"
         self._key = key
         self._properties = properties  # Properties dict as provided by zero conf
 
@@ -41,7 +44,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
         self._api_header = "X-Api-Key"
         self._api_key = None
 
-        self._base_url = "http://%s:%d%s" % (self._address, self._port, self._path)
+        self._base_url = "%s://%s:%d%s" % ("https" if self._useHttps else "http", self._address, self._port, self._path)
         self._api_url = self._base_url + self._api_prefix
         self._camera_url = "http://%s:8080/?action=stream" % self._address
 
@@ -145,6 +148,11 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
     @pyqtProperty(str, constant=True)
     def path(self):
         return self._path
+
+    ## path of this instance
+    @pyqtProperty(bool, constant=True)
+    def useHttps(self):
+        return self._useHttps
 
     ## absolute url of this instance
     @pyqtProperty(str, constant=True)

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -28,7 +28,6 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
         self._path = properties.get(b"path", b"/").decode("utf-8")
         if self._path[-1:] != "/":
             self._path += "/"
-        self._useHttps = properties.get(b'useHttps') == b"true"
         self._key = key
         self._properties = properties  # Properties dict as provided by zero conf
 
@@ -44,9 +43,10 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
         self._api_header = "X-Api-Key"
         self._api_key = None
 
-        self._base_url = "%s://%s:%d%s" % ("https" if self._useHttps else "http", self._address, self._port, self._path)
+        protocol = "https" if properties.get(b'useHttps') == b"true" else "http"
+        self._base_url = "%s://%s:%d%s" % (protocol, self._address, self._port, self._path)
         self._api_url = self._base_url + self._api_prefix
-        self._camera_url = "http://%s:8080/?action=stream" % self._address
+        self._camera_url = "%s://%s:8080/?action=stream" % (protocol, self._address)
 
         self.setPriority(2) # Make sure the output device gets selected above local file output
         self.setName(key)
@@ -148,11 +148,6 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
     @pyqtProperty(str, constant=True)
     def path(self):
         return self._path
-
-    ## path of this instance
-    @pyqtProperty(bool, constant=True)
-    def useHttps(self):
-        return self._useHttps
 
     ## absolute url of this instance
     @pyqtProperty(str, constant=True)

--- a/OctoPrintOutputDevicePlugin.py
+++ b/OctoPrintOutputDevicePlugin.py
@@ -60,14 +60,18 @@ class OctoPrintOutputDevicePlugin(OutputDevicePlugin):
 
         # Add manual instances from preference
         for name, properties in self._manual_instances.items():
-            additional_properties = {b"path": properties["path"].encode("utf-8"), b"manual": b"true"}
+            additional_properties = {
+                b"path": properties["path"].encode("utf-8"),
+                b"useHttps": b"true" if properties.get("useHttps", False) else b"false",
+                b"manual": b"true"
+            } # These additional properties use bytearrays to mimick the output of zeroconf
             self.addInstance(name, properties["address"], properties["port"], additional_properties)
 
-    def addManualInstance(self, name, address, port, path):
-        self._manual_instances[name] = {"address": address, "port": port, "path": path}
+    def addManualInstance(self, name, address, port, path, useHttps = False):
+        self._manual_instances[name] = {"address": address, "port": port, "path": path, "useHttps": useHttps}
         self._preferences.setValue("octoprint/manual_instances", json.dumps(self._manual_instances))
 
-        properties = { b"path": path.encode("utf-8"), b"manual": b"true" }
+        properties = { b"path": path.encode("utf-8"), b"useHttps": b"true" if useHttps else b"false", b"manual": b"true" }
 
         if name in self._instances:
             self.removeInstance(name)


### PR DESCRIPTION
This PR adds an option to use the https protocol instead of http for manual instances. Note that OctoPrint does not natively support https connections, but this may be useful for people that have set up a https-enabled proxy.