### PR TITLE
Prevent a crash when printer do not have heating bed.

### DIFF
--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -562,10 +562,11 @@ class OctoPrintOutputDevice(NetworkedPrinterOutputDevice):
 
                         if "bed" in json_data["temperature"]:
                             bed_temperatures = json_data["temperature"]["bed"]
-                            printer.updateBedTemperature(bed_temperatures["actual"])
+                            actual_temperature = bed_temperatures["actual"] if bed_temperatures["actual"] is not None else -1
+                            printer.updateBedTemperature(actual_temperature)
                             printer.updateTargetBedTemperature(bed_temperatures["target"])
                         else:
-                            printer.updateBedTemperature(0)
+                            printer.updateBedTemperature(-1)
                             printer.updateTargetBedTemperature(0)
 
                     printer_state = "offline"

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -564,7 +564,8 @@ class OctoPrintOutputDevice(NetworkedPrinterOutputDevice):
                             bed_temperatures = json_data["temperature"]["bed"]
                             actual_temperature = bed_temperatures["actual"] if bed_temperatures["actual"] is not None else -1
                             printer.updateBedTemperature(actual_temperature)
-                            printer.updateTargetBedTemperature(bed_temperatures["target"])
+                            target_temperature = bed_temperatures["target"] if bed_temperatures["target"] is not None else -1
+                            printer.updateTargetBedTemperature(target_temperature)
                         else:
                             printer.updateBedTemperature(-1)
                             printer.updateTargetBedTemperature(0)


### PR DESCRIPTION
When printer do not have heating bed, octoprint send None for actual
temperature of the bed and Cura crash.
Set it to -1 to hide the bed component
(will work when Ultimaker/Cura#3811 will be merged)