### PR TITLE
Add note on Arch Linux requiring python-zeroconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
     found via Help -> Show Configuration Folder inside Cura.
     NB: The folder of the plugin itself *must* be ```OctoPrintPlugin```
     NB: Make sure you download the branch that matches the Cura branch (ie: 2.4 for Cura 2.4 etc)
-  - If you are running Cura from source, make sure you install python-zeroconf using pip:
+  - If you are running Cura from source or are using the Arch Linux package, make sure you install python-zeroconf using pip:
     ```pip3 install python3-zeroconf```.
     Released versions of Cura already meet this requirement.
 * Cura PPA (*Ubuntu):

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
     found via Help -> Show Configuration Folder inside Cura.
     NB: The folder of the plugin itself *must* be ```OctoPrintPlugin```
     NB: Make sure you download the branch that matches the Cura branch (ie: 2.4 for Cura 2.4 etc)
-  - If you are running Cura from source or are using the Arch Linux package, make sure you install python-zeroconf using pip:
+  - If you are running Cura from source or are using an unofficial distribution of Cura (such as the Arch Linux package), make sure you install python-zeroconf using the system package manager or pip:
     ```pip3 install python3-zeroconf```.
     Released versions of Cura already meet this requirement.
 * Cura PPA (*Ubuntu):


### PR DESCRIPTION
Arch Linux's distribution of Cura doesn't have a required dependency on python-zeroconf so add a note in the README to indicate it needs to be installed.

This probably should generate an actual dialog in the user's face so they know to do this as simply not working and not displaying any error even in the plugins list is less than ideal.